### PR TITLE
Fix error casting net.minecraft.client.multiplayer.ClientLevel to class net.minecraft.server.level.ServerLevel

### DIFF
--- a/src/main/java/coda/breezy/Breezy.java
+++ b/src/main/java/coda/breezy/Breezy.java
@@ -85,7 +85,11 @@ public class Breezy {
             WindDirectionSavedData.resetWindDirection(world.random);
             
             world.players().forEach(player -> {
-                WindDirectionSavedData data = ((ServerLevel) player.getLevel()).getDataStorage().computeIfAbsent(WindDirectionSavedData::new, () -> new WindDirectionSavedData(player.getLevel().getRandom()), Breezy.MOD_ID + ".savedata");
+                var level = player.getLevel();
+
+                if (level.isClientSide) return;
+                
+                WindDirectionSavedData data = ((ServerLevel) level).getDataStorage().computeIfAbsent(WindDirectionSavedData::new, () -> new WindDirectionSavedData(level.getRandom()), Breezy.MOD_ID + ".savedata");
                 BreezyNetworking.sendToPlayer(new WindDirectionPacket(data), (ServerPlayer) player);
             });
         }


### PR DESCRIPTION
Issue:
On minecraft load it sometimes crashes with error
```
java.lang.ClassCastException: class net.minecraft.client.multiplayer.ClientLevel cannot be cast to class net.minecraft.server.level.ServerLevel (net.minecraft.client.multiplayer.ClientLevel and net.minecraft.server.level.ServerLevel are in module minecraft@1.18.2 of loader 'TRANSFORMER' @48277712)
	at coda.breezy.Breezy.lambda$resetWindDirection$1(Breezy.java:88) ~[breezy-1.18.2-1.0.3.jar%23151!/:1.18.2-1.0.3] {re:classloading}
```

Found another mod which had the same issue resolved:
https://github.com/TheCBProject/CBMultipart/issues/87

Adding `if (level.isClientSide) return;` has fixed game load crash for my test setup.
This fix switches off logic if it is run on client side.

Fix for issues:
https://github.com/Coda1552/Breezy/issues/17
https://github.com/Coda1552/Breezy/issues/19
https://github.com/Coda1552/Breezy/issues/21