### PR TITLE
Fixed 1.18.2 clientside crash

### DIFF
--- a/src/main/java/coda/breezy/Breezy.java
+++ b/src/main/java/coda/breezy/Breezy.java
@@ -85,7 +85,7 @@ public class Breezy {
             WindDirectionSavedData.resetWindDirection(world.random);
             
             world.players().forEach(player -> {
-                Level level = player.getLevel();
+                var level = player.getLevel();
 
                 if (level.isClientSide) return;
                 


### PR DESCRIPTION
This is a tiny tweak that should prevent a crash that was occuring on a clientside level mismatch due to a variable cast that couldn't occur